### PR TITLE
Added: API for getting all FAQ items

### DIFF
--- a/app/Http/Controllers/Api/v1/Faq/Controllers/FaqController.php
+++ b/app/Http/Controllers/Api/v1/Faq/Controllers/FaqController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1\Faq\Controllers;
+
+use App\Http\Controllers\Api\v1\Faq\Mappers\FaqMapper;
+use App\Models\Faq;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class FaqController extends Controller
+{
+
+    use FaqMapper;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Get a list of mensas
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $faqs = Faq::orderBy('order')
+            ->get()
+            ->map(function ($faq) {
+                return self::mapFaq($faq);
+            });
+
+        return response()->json([
+            "faqs" => $faqs
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/v1/Faq/Mappers/FaqMapper.php
+++ b/app/Http/Controllers/Api/v1/Faq/Mappers/FaqMapper.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1\Faq\Mappers;
+
+use App\Http\Controllers\Api\v1\Faq\Models\FaqResponseModel;
+use App\Models\Faq;
+
+trait FaqMapper
+{
+    function mapFaq(Faq $faq): FaqResponseModel
+    {
+        return new FaqResponseModel(
+            id: $faq->id,
+            question: $faq->question,
+            answer: $faq->answer,
+        );
+    }
+}

--- a/app/Http/Controllers/Api/v1/Faq/Models/FaqResponseModel.php
+++ b/app/Http/Controllers/Api/v1/Faq/Models/FaqResponseModel.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Http\Controllers\Api\v1\Faq\Models;
+
+class FaqResponseModel {
+
+    public function __construct(
+        public string $id,
+        public string $question,
+        public string $answer
+    )
+    {
+    }
+}

--- a/app/Http/Controllers/Api/v1/Mensa/Mappers/ExtraOptionsMapper.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Mappers/ExtraOptionsMapper.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Mappers;
 
-use App\Http\Controllers\Api\v1\Mensa\Models\ExtraOptionItem;
+use App\Http\Controllers\Api\v1\Mensa\Models\ExtraOptionResponseModel;
 use App\Models\ExtraOption;
 
 
@@ -10,21 +10,21 @@ trait ExtraOptionsMapper
 {
     /**
      * @param ExtraOption $extraOption
-     * @return ExtraOptionItem
+     * @return ExtraOptionResponseModel
      */
-    function mapExtraOption(ExtraOption $extraOption): ExtraOptionItem
+    function mapExtraOption(ExtraOption $extraOption): ExtraOptionResponseModel
     {
-        return new ExtraOptionItem(
-            $extraOption->id,
-            $extraOption->description,
-            $extraOption->order,
-            $extraOption->price
+        return new ExtraOptionResponseModel(
+            id: $extraOption->id,
+            description: $extraOption->description,
+            order: $extraOption->order,
+            price: $extraOption->price
         );
     }
 
     /**
      * @param ExtraOption[] $extraOptions
-     * @return ExtraOptionItem[]
+     * @return ExtraOptionResponseModel[]
      */
     function mapExtraOptions(array $extraOptions): array
     {

--- a/app/Http/Controllers/Api/v1/Mensa/Mappers/MensaMapper.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Mappers/MensaMapper.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Api\v1\Mensa\Mappers;
 
 use App\Http\Controllers\Api\v1\Common\Mappers\FoodOptionsMapper;
 use App\Http\Controllers\Api\v1\Mensa\Models\MensaDetailItem;
-use App\Http\Controllers\Api\v1\Mensa\Models\MensaItem;
+use App\Http\Controllers\Api\v1\Mensa\Models\MensaResponseModel;
 use App\Models\ExtraOption;
 use App\Models\Mensa;
 use App\Models\MenuItem;
@@ -19,7 +19,7 @@ trait MensaMapper
      * @param Signup[] $users
      * @param MenuItem[] $menu
      * @param ExtraOption[] $options
-     * @return MensaItem
+     * @return MensaResponseModel
      */
     function mapMensa(
         Mensa $mensa,
@@ -27,7 +27,7 @@ trait MensaMapper
         array $menu,
         array $options,
         bool $isLoggedIn
-    ): MensaItem
+    ): MensaResponseModel
     {
         $dishwashers = array_filter($users, function ($user) {
             return $user->dishwasher;
@@ -45,7 +45,7 @@ trait MensaMapper
             $signups = array_map($userSignupMapper, $users);
         }
 
-        return new MensaItem(
+        return new MensaResponseModel(
             id: $mensa->id,
             title: $mensa->title,
             description: $mensa->description,

--- a/app/Http/Controllers/Api/v1/Mensa/Mappers/MenuItemMapper.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Mappers/MenuItemMapper.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Mappers;
 
-use App\Http\Controllers\Api\v1\Mensa\Models\MenuItemItem;
+use App\Http\Controllers\Api\v1\Mensa\Models\MenuItemResponseModel;
 use App\Models\MenuItem;
 
 trait MenuItemMapper
@@ -10,11 +10,11 @@ trait MenuItemMapper
 
     /**
      * @param $menuItem MenuItem
-     * @return MenuItemItem
+     * @return MenuItemResponseModel
      */
-    function mapMenuItem(MenuItem $menuItem): MenuItemItem
+    function mapMenuItem(MenuItem $menuItem): MenuItemResponseModel
     {
-        return new MenuItemItem(
+        return new MenuItemResponseModel(
             id: $menuItem->id,
             text: $menuItem->text
         );
@@ -22,7 +22,7 @@ trait MenuItemMapper
 
     /**
      * @param MenuItem[] $menuItems
-     * @return MenuItemItem[]
+     * @return MenuItemResponseModel[]
      */
     function mapMenuItems(array $menuItems): array
     {

--- a/app/Http/Controllers/Api/v1/Mensa/Mappers/SignupMapper.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Mappers/SignupMapper.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Mappers;
 
-use App\Http\Controllers\Api\v1\Mensa\Models\SignupItem;
+use App\Http\Controllers\Api\v1\Mensa\Models\SignupResponseModel;
 use App\Models\Signup;
 use App\Models\User;
 
@@ -13,11 +13,11 @@ trait SignupMapper
     /**
      * @param Signup $signup
      * @param User|null $user
-     * @return SignupItem
+     * @return SignupResponseModel
      */
-    function mapSignup(Signup $signup, User $user = null): SignupItem
+    function mapSignup(Signup $signup, User $user = null): SignupResponseModel
     {
-        return new SignupItem(
+        return new SignupResponseModel(
             id: $signup->id,
             user: self::mapUser($user ?? $signup->user),
             allergies: $signup->allergies,

--- a/app/Http/Controllers/Api/v1/Mensa/Mappers/UserMapper.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Mappers/UserMapper.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Mappers;
 
-use App\Http\Controllers\Api\v1\Mensa\Models\SimpleUserItem;
+use App\Http\Controllers\Api\v1\Mensa\Models\SimpleUserResponseModel;
 use App\Http\Controllers\Api\v1\Utils\User\UserCache;
 use App\Models\Signup;
 use App\Models\User;
@@ -11,17 +11,17 @@ trait UserMapper
 {
     /**
      * @param User $user
-     * @return SimpleUserItem
+     * @return SimpleUserResponseModel
      */
-    function mapUser(User $user): SimpleUserItem
+    function mapUser(User $user): SimpleUserResponseModel
     {
-        return new SimpleUserItem(
-            $user->id,
-            $user->name,
+        return new SimpleUserResponseModel(
+            id: $user->id,
+            name: $user->name,
         );
     }
 
-    function mapUserFromSignup(Signup $signup): SimpleUserItem
+    function mapUserFromSignup(Signup $signup): SimpleUserResponseModel
     {
         return $this->mapUser(UserCache::getCachedUser($signup->user_id));
     }

--- a/app/Http/Controllers/Api/v1/Mensa/Models/ExtraOptionResponseModel.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Models/ExtraOptionResponseModel.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Models;
 
-class ExtraOptionItem
+class ExtraOptionResponseModel
 {
     /**
-     * ExtraOptionItem constructor.
+     * ExtraOptionResponseModel constructor.
      * @param string $id
      * @param string $description
      * @param int $order

--- a/app/Http/Controllers/Api/v1/Mensa/Models/MensaResponseModel.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Models/MensaResponseModel.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Models;
 
-class MensaItem
+class MensaResponseModel
 {
     /**
-     * MensaItem constructor.
+     * MensaResponseModel constructor.
      * @param string $id
      * @param string $title
      * @param string $description
@@ -13,13 +13,13 @@ class MensaItem
      * @param int $closingTime
      * @param bool $isClosed
      * @param int $maxSignups
-     * @param int|SimpleUserItem[] $signups
+     * @param int|SimpleUserResponseModel[] $signups
      * @param int $dishwashers
      * @param float $price
-     * @param SimpleUserItem[] $cooks
+     * @param SimpleUserResponseModel[] $cooks
      * @param string[] $foodOptions
-     * @param MenuItemItem[] $menu
-     * @param ExtraOptionItem[] $extraOptions
+     * @param MenuItemResponseModel[] $menu
+     * @param ExtraOptionResponseModel[] $extraOptions
      */
     public function __construct(
         public string $id,

--- a/app/Http/Controllers/Api/v1/Mensa/Models/MenuItemResponseModel.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Models/MenuItemResponseModel.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Models;
 
-class MenuItemItem
+class MenuItemResponseModel
 {
     /**
-     * MenuItemItem constructor.
+     * MenuItemResponseModel constructor.
      * @param string $id
      * @param string $text
      */

--- a/app/Http/Controllers/Api/v1/Mensa/Models/SignupResponseModel.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Models/SignupResponseModel.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Models;
 
-class SignupItem
+class SignupResponseModel
 {
 
     /**
-     * SimpleUserItem constructor.
+     * SimpleUserResponseModel constructor.
      * @param string $id
-     * @param SimpleUserItem $user
+     * @param SimpleUserResponseModel $user
      * @param string $allergies
      * @param string $extraInfo
      * @param int $food_option
@@ -17,7 +17,7 @@ class SignupItem
      */
     public function __construct(
         public string $id,
-        public SimpleUserItem $user,
+        public SimpleUserResponseModel $user,
         public string $allergies,
         public string $extraInfo,
         public int $food_option,

--- a/app/Http/Controllers/Api/v1/Mensa/Models/SimpleUserResponseModel.php
+++ b/app/Http/Controllers/Api/v1/Mensa/Models/SimpleUserResponseModel.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\v1\Mensa\Models;
 
-class SimpleUserItem
+class SimpleUserResponseModel
 {
 
     /**
-     * SimpleUserItem constructor.
+     * SimpleUserResponseModel constructor.
      * @param string $id
      * @param string $name
      */

--- a/app/Http/Controllers/Api/v1/User/Mappers/UserMapper.php
+++ b/app/Http/Controllers/Api/v1/User/Mappers/UserMapper.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api\v1\User\Mappers;
 
 use App\Http\Controllers\Api\v1\Common\Mappers\FoodOptionsMapper;
-use App\Http\Controllers\Api\v1\User\Models\UserSelf;
+use App\Http\Controllers\Api\v1\User\Models\UserResponseModel;
 use App\Models\User;
 
 trait UserMapper
@@ -12,7 +12,7 @@ trait UserMapper
 
     function mapUser(User $user)
     {
-        return new UserSelf(
+        return new UserResponseModel(
             id: $user->id,
             name: $user->name,
             email: $user->email,

--- a/app/Http/Controllers/Api/v1/User/Models/UserResponseModel.php
+++ b/app/Http/Controllers/Api/v1/User/Models/UserResponseModel.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Api\v1\User\Models;
 
-class UserSelf
+class UserResponseModel
 {
     public function __construct(
         public string $id,

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,8 @@ Route::prefix("v1")->middleware('jsonRequests')->group(function () {
     Route::patch('mensa/{mensaId}/signup/{signupId}/confirm', 'Api\v1\Mensa\Controllers\SignupController@confirmSignup');
     Route::delete('mensa/{mensaId}/signup/{signupId}', 'Api\v1\Mensa\Controllers\SignupController@deleteSignup');
 
+    Route::get('faqs', 'Api\v1\Faq\Controllers\FaqController');
+
     Route::get('user/self', 'Api\v1\User\Controllers\SelfController@getSelf');
     Route::patch('user/self/update', 'Api\v1\User\Controllers\SelfController@updateSelf');
 


### PR DESCRIPTION
Also took some liberty to implement a code convention: ...ResponseModel are the only models that are allowed to be sent to the user. If we ever get models from the users, we will call them ...RequestModel. This is to make a clear distinction between our database models and our response models.